### PR TITLE
Docs did not have an import statement

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -271,6 +271,7 @@ make the current mailer an instance of the
 
         def test_some_view(self):
             from pyramid.testing import DummyRequest
+            from pyramid_mailer import get_mailer
             request = DummyRequest()
             mailer = get_mailer(request)
             response = some_view(request)


### PR DESCRIPTION
The docs for pyramid_mailer test support had an import statement missing.
