### PR TITLE
fix for #19

### DIFF
--- a/pyramid_mailer/mailer.py
+++ b/pyramid_mailer/mailer.py
@@ -165,6 +165,10 @@ class Mailer(object):
         kwargs = dict(((k[size:], settings[k]) for k in settings.keys() if
                         k in kwarg_names))
 
+        for key in ('tls', 'ssl'):
+            if key in kwargs and str(kwargs[key]).strip().lower() in (0, 'false'):
+                kwargs[key] = False
+
         return cls(**kwargs)
 
     def send(self, message):

--- a/pyramid_mailer/tests.py
+++ b/pyramid_mailer/tests.py
@@ -580,7 +580,7 @@ class TestMailer(unittest.TestCase):
                     'mymail.port' : 123,
                     'mymail.username' : 'tester',
                     'mymail.password' : 'test',
-                    'mymail.tls' : True,
+                    'mymail.tls' : 'false',
                     'mymail.ssl' : True,
                     'mymail.keyfile' : 'ssl.key',
                     'mymail.certfile' : 'ssl.crt',
@@ -593,7 +593,7 @@ class TestMailer(unittest.TestCase):
         self.assertEqual(mailer.direct_delivery.mailer.port, 123)
         self.assertEqual(mailer.direct_delivery.mailer.username, 'tester')
         self.assertEqual(mailer.direct_delivery.mailer.password, 'test')
-        self.assertEqual(mailer.direct_delivery.mailer.force_tls, True)
+        self.assertEqual(mailer.direct_delivery.mailer.force_tls, False)
         if ssl_enabled:
             self.assertEqual(mailer.direct_delivery.mailer.smtp, SMTP_SSL)
         else: # pragma: no cover


### PR DESCRIPTION
Hi,
here is a simple fix for the tls and ssl settings so that when people set it as False in the deploy.ini they are considered False for pyramid_mailer
