### PR TITLE
Decode email's payload with 'ascii' when sending with attachment

### DIFF
--- a/pyramid_mailer/response.py
+++ b/pyramid_mailer/response.py
@@ -412,14 +412,22 @@ def is_nonstr_iter(v): # pragma: no cover
     return hasattr(v, '__iter__')
 
 def encode_string(encoding, data):
+    """ return the string decoded with ascii
+    In Python3, the encodestring method returns 'bytes' string and
+    the email module expects 'str' string. Passing the unicode string
+    to the email module is also OK even if in Python 2.x.
+    """
     encoded = data
     if encoding == 'base64':
-        encoded = base64.encodestring(data)
+        encoded = b64encodestring(data).decode('ascii')
     elif encoding == 'quoted-printable':
-        encoded = quopri.encodestring(data)
+        encoded = quopri.encodestring(data).decode('ascii')
     return encoded
 
 # BBB Python 2 vs 3 compat
 if sys.version < '3':
     def is_nonstr_iter(v):
         return hasattr(v, '__iter__')
+    b64encodestring = base64.encodestring
+else:
+    b64encodestring = base64.encodebytes

--- a/pyramid_mailer/tests.py
+++ b/pyramid_mailer/tests.py
@@ -939,10 +939,9 @@ class TestMailResponse(unittest.TestCase):
         self.assertEqual(message.__class__, MIMEPart)
 
     def test_to_message_multipart_with_b64encoding(self):
-        from pyramid_mailer.response import MIMEPart
+        from pyramid_mailer.response import MIMEPart, b64encodestring
         response = self._makeOne(To='To', From='From', Subject='Subject',
                                  Body='Body', Html='Html')
-        import base64
         import os
         this = os.path.abspath(__file__)
         data = self._read_filedata(this, mode='rb')
@@ -953,7 +952,8 @@ class TestMailResponse(unittest.TestCase):
         self.assertEqual(message.__class__, MIMEPart)
         payload = message.get_payload()[0]
         self.assertEqual(payload.get('Content-Transfer-Encoding'), 'base64')
-        self.assertEqual(payload.get_payload(), base64.encodestring(data))
+        self.assertEqual(payload.get_payload(),
+                         b64encodestring(data).decode('ascii'))
 
     def test_to_message_multipart_with_qpencoding(self):
         from pyramid_mailer.response import MIMEPart
@@ -972,7 +972,8 @@ class TestMailResponse(unittest.TestCase):
         payload = message.get_payload()[0]
         self.assertEqual(payload.get('Content-Transfer-Encoding'),
                          'quoted-printable')
-        self.assertEqual(payload.get_payload(), quopri.encodestring(data))
+        self.assertEqual(payload.get_payload(),
+                         quopri.encodestring(data).decode('ascii'))
 
     def test_to_message_with_parts(self):
         from pyramid_mailer.response import MIMEPart


### PR DESCRIPTION
Fix #24
