### PR TITLE
Force encode_string to return a string and not bytes.

### DIFF
--- a/pyramid_mailer/response.py
+++ b/pyramid_mailer/response.py
@@ -417,7 +417,7 @@ def encode_string(encoding, data):
         encoded = base64.encodestring(data)
     elif encoding == 'quoted-printable':
         encoded = quopri.encodestring(data)
-    return encoded
+    return encoded.decode('ascii')
 
 # BBB Python 2 vs 3 compat
 if sys.version < '3':

--- a/pyramid_mailer/tests.py
+++ b/pyramid_mailer/tests.py
@@ -446,6 +446,7 @@ class TestMailer(unittest.TestCase):
     def test_send(self):
 
         from pyramid_mailer.mailer import Mailer
+        from pyramid_mailer.message import Attachment
         from pyramid_mailer.message import Message
 
         mailer = Mailer()
@@ -454,6 +455,9 @@ class TestMailer(unittest.TestCase):
                       sender="sender@example.com",
                       recipients=["tester@example.com"],
                       body="test")
+        msg.attach(Attachment('test.txt',
+                              data=b"this is a test", 
+                              content_type="text/plain"))
 
         mailer.send(msg)
 
@@ -953,7 +957,7 @@ class TestMailResponse(unittest.TestCase):
         self.assertEqual(message.__class__, MIMEPart)
         payload = message.get_payload()[0]
         self.assertEqual(payload.get('Content-Transfer-Encoding'), 'base64')
-        self.assertEqual(payload.get_payload(), base64.encodestring(data))
+        self.assertEqual(payload.get_payload(), base64.encodestring(data).decode('ascii'))
 
     def test_to_message_multipart_with_qpencoding(self):
         from pyramid_mailer.response import MIMEPart
@@ -972,7 +976,7 @@ class TestMailResponse(unittest.TestCase):
         payload = message.get_payload()[0]
         self.assertEqual(payload.get('Content-Transfer-Encoding'),
                          'quoted-printable')
-        self.assertEqual(payload.get_payload(), quopri.encodestring(data))
+        self.assertEqual(payload.get_payload(), quopri.encodestring(data).decode('ascii'))
 
     def test_to_message_with_parts(self):
         from pyramid_mailer.response import MIMEPart


### PR DESCRIPTION
This is required to actually send a message with a binary attachment
because the email.generator module from the standard Python library
expect the parts of a multi part message to be strings, not bytes.

This can be reproduced with the modified test TestMailer.test_send

This patch also fix two tests that would fail after the change in
the encode_string function.
