### PR TITLE
Do not supply charset parameter to set_payload.

### DIFF
--- a/pyramid_mailer/message.py
+++ b/pyramid_mailer/message.py
@@ -451,15 +451,13 @@ def to_message(base):
     if is_multipart:
         out = MIMEMultipart(subtype, **ctparams)
     else:
-        out = MIMENonMultipart(maintype, subtype, **ctparams)
-        if ctenc:
-            out['Content-Transfer-Encoding'] = ctenc
         if isinstance(body, text_type):
             if not charset:
                 if is_text:
                     charset, _ = best_charset(body)
                 else:
                     charset = 'utf-8'
+                ctparams['charset'] = charset
             if PY2:
                 body = body.encode(charset)
             else: # pragma: no cover
@@ -469,7 +467,10 @@ def to_message(base):
                 body = transfer_encode(ctenc, body)
             if not PY2: # pragma: no cover
                 body = body.decode(charset or 'ascii', 'replace')
-        out.set_payload(body, charset) 
+        out = MIMENonMultipart(maintype, subtype, **ctparams)
+        if ctenc:
+            out['Content-Transfer-Encoding'] = ctenc
+        out.set_payload(body)
 
     for k in base.keys(): # returned sorted
         value = base[k]


### PR DESCRIPTION
Specifying the charset to email.message.Message eventually instructs it to dismiss the charset specified in Content-Type and furthermore recode the payload charset according to the global mappings predefined in the module, which is totally unwanted.
