### PR TITLE
Support `7bit' and `8bit' transfer-encoding, in order to expand encoded characters verbatim into the payload.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+0.14 (2013-XX-XX)
+-----------------
+
+- Support '7bit' and '8bit' transfer-encoding.
+  See https://github.com/Pylons/pyramid_mailer/pull/49 .
+
 0.13 (2013-07-13)
 -----------------
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -128,3 +128,5 @@ Contributors
 - Bert JW Regeer, 2013-07-13
 
 - Supreet Sethi, 2013-07-23
+
+- Moriyoshi Koizumi, 2013/08/27

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -260,8 +260,8 @@ could be rewritten::
     message.attach(attachment)
 
 A transfer encoding can be specified via the ``transfer_encoding`` option.
-Supported options are currently ``base64`` (the default) and
-``quoted-printable``.
+Supported options are currently ``quoted-printable`` (default), ``base64``,
+``7bit`` and ``8bit``.
 
 You can also pass an attachment as the ``body`` and/or ``html``
 arguments to specify ``Content-Transfer-Encoding`` or other

--- a/pyramid_mailer/message.py
+++ b/pyramid_mailer/message.py
@@ -499,6 +499,14 @@ def transfer_encode(encoding, payload):
         return _bencode(payload)
     elif encoding == 'quoted-printable':
         return _qencode(payload)
+    elif encoding == '7bit':
+        try:
+            text_type(payload, 'ascii')
+        except UnicodeDecodeError:
+            raise RuntimeError('Payload contains an octet that is not 7bit safe')
+        return payload
+    elif encoding == '8bit':
+        return payload
     else:
         raise RuntimeError('Unknown transfer encoding %s' % encoding)
 

--- a/pyramid_mailer/tests/test_message.py
+++ b/pyramid_mailer/tests/test_message.py
@@ -1069,6 +1069,23 @@ class Test_transfer_encode(unittest.TestCase):
             _qencode(text_encoded)
             )
 
+    def test_body_is_7bit(self):
+        text_encoded = b'LaPe\xf1a'
+        text_7bit = b'LaPena'
+        self.assertEqual(
+            self._callFUT('7bit', text_7bit),
+            text_7bit
+            )
+        with self.assertRaises(RuntimeError):
+            self._callFUT('7bit', text_encoded) 
+
+    def test_body_is_8bit(self):
+        text_encoded = b'LaPe\xf1a'
+        self.assertEqual(
+            self._callFUT('8bit', text_encoded),
+            text_encoded
+            )
+
     def test_unknown_encoding(self):
         text_encoded = b'LaPe\xf1a'
         self.assertRaises(


### PR DESCRIPTION
It sometimes is necessary to pass an already composed Attachment object to pyramid_mailer in order to gain more control over the whole message being delivered.  In such a case, it would be handier if 7bit or 8bit encoding can be specified as transfer_encoding.
