### PR TITLE
add pyramid_mailer.debug shorthand

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+0.14 (Unreleased)
+-----------------
+
+- Add pyramid_mailer.debug shorthand to easily enable (one line in
+  development.ini) writing emails to a file instead of sending them out.
+
 0.13 (2013-07-13)
 -----------------
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -128,3 +128,5 @@ Contributors
 - Bert JW Regeer, 2013-07-13
 
 - Supreet Sethi, 2013-07-23
+
+- Nejc Zupan, 2013-11-08

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -277,15 +277,30 @@ arguments to specify ``Content-Transfer-Encoding`` or other
     message = Message(body=body, html=html)
 
 
+Debugging
+---------
+
+If your site is in development and you want to avoid accidental sending of any
+emails to customers, but still see what emails would get sent, you can use
+``config.include('pyramid_mailer.debug')`` to make the current mailer an
+instance of the :class:`pyramid_mailer.mailer.DebugMailer`, hence writing all
+emails to a file instead of sending them out. In other words if you add
+``pyramid_mailer.debug`` to your development.ini, all emails that would be sent
+out will instead get written to files so you can inspect them::
+
+   pyramid.includes =
+      pyramid_mailer.debug
+      ...
+      pyramid_debugtoolbar
+      pyramid_tm
+
+
 Unit tests
 ----------
 
 When running unit tests you probably don't want to actually send any emails
 inadvertently. However it's still useful to keep track of what emails would
 be sent in your tests.
-
-Another case is if your site is in development and you want to avoid
-accidental sending of any emails to customers.
 
 In either case, ``config.include('pyramid_mailer.testing')`` can be used to
 make the current mailer an instance of the

--- a/pyramid_mailer/debug.py
+++ b/pyramid_mailer/debug.py
@@ -1,0 +1,9 @@
+import os
+from pyramid_mailer.interfaces import IMailer
+from pyramid_mailer.mailer import DebugMailer
+
+
+def includeme(config):
+    path = os.path.join(os.getcwd(), 'mail')
+    mailer = DebugMailer(path)
+    config.registry.registerUtility(mailer, IMailer)

--- a/pyramid_mailer/tests/test_debug.py
+++ b/pyramid_mailer/tests/test_debug.py
@@ -1,0 +1,30 @@
+import unittest
+
+
+class TestIncludemeDebug(unittest.TestCase):
+    def test_includeme(self):
+        from pyramid_mailer.interfaces import IMailer
+        from pyramid_mailer.mailer import DebugMailer
+        from pyramid_mailer.debug import includeme
+
+        registry = DummyRegistry()
+        config = DummyConfig(registry, {})
+        includeme(config)
+        self.assertEqual(registry.registered[IMailer].__class__, DebugMailer)
+
+
+class DummyRegistry(object):
+    def __init__(self, result=None):
+        self.result = result
+        self.registered = {}
+
+    def registerUtility(self, impl, iface):
+        self.registered[iface] = impl
+
+
+class DummyConfig(object):
+    def __init__(self, registry, settings):
+        self.registry = registry
+        self.registry.settings = settings
+
+


### PR DESCRIPTION
To easily enable (one line in development.ini) writing emails to a file instead of sending them out.
