### PR TITLE
Set a default message sender if no sender set in DebugMailer

### DIFF
--- a/pyramid_mailer/mailer.py
+++ b/pyramid_mailer/mailer.py
@@ -46,6 +46,8 @@ class DebugMailer(object):
         file_part2 = ''.join(sample(seeds, 4))
         filename = join(self.tld, '%s_%s.msg' % (file_part1, file_part2))
         with open(filename, 'w') as fd:
+            if not message.sender:
+                message.sender = 'nobody'
             fd.write(str(message.to_message()))
 
     send = _send

--- a/pyramid_mailer/tests/test_mailer.py
+++ b/pyramid_mailer/tests/test_mailer.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 
 
@@ -57,6 +58,15 @@ class DebugMailerTests(_Base):
         mailer.send_sendmail(msg)
         files = self._listFiles()
         self.assertEqual(len(files), 1)
+
+    def test_default_sender(self):
+        mailer = self._makeOne()
+        msg = _makeMessage(sender=None)
+        mailer.send_sendmail(msg)
+        files = self._listFiles()
+        self.assertEqual(len(files), 1)
+        msg = open(os.path.join(self._tempdir, files[0]), 'r')
+        self.assertIn('From: nobody', msg.read())
 
 
 class DummyMailerTests(unittest.TestCase):


### PR DESCRIPTION
Use-case: I construct Messages in my code without a sender, because I want to
use the `default_sender` as the sender. Works as a charm with `Mailer`.

However, when I use `DebugMailer` with these Messages, I get a message a
validation error, because the sender is not set. The `Mailer` class takes
care of setting the sender if default sender is set, but the `DebugMailer`
does not do that. This patch then sets a dummy sender, if no sender is set in
Message, to allow using `DebugMailer` with sender-less Messages.
