### PR TITLE
Fixing a test for None on both variables in body and html

### DIFF
--- a/pyramid_mailer/message.py
+++ b/pyramid_mailer/message.py
@@ -293,7 +293,7 @@ class Message(object):
         if not (self.recipients or self.cc or self.bcc):
             raise InvalidMessage("No recipients have been added")
 
-        if not self.body and not self.html:
+        if self.body and self.html == None:
             raise InvalidMessage("No body has been set")
 
         if not self.sender:


### PR DESCRIPTION
If body variable didn't exist and html did, pyramid_mailer was assuming both were empty, note that I only discovered this when moving from message.send() to message.send_to_queue(), but nevertheless this fix does the same thing as before, but this actually is a true test on both variables being empty.
