### PR TITLE
Treat blank username, password in settings as None

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Next Release
+------------
+
+- If ``username`` and ``password`` are both set to the empty string,
+  ``Mailer.from_settings``, now interprets them as being set to ``None``.
+  Previously, setting them to the empty string caused SMTP authentication
+  to be force with empty username and password.
+
 0.14.1 (2015-05-21)
 -------------------
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -132,3 +132,5 @@ Contributors
 - Nejc Zupan, 2013-11-08
 
 - Mário Idival, 2015-05-21
+
+- Geoffrey T. Dairiki, 2015-06-30

--- a/pyramid_mailer/mailer.py
+++ b/pyramid_mailer/mailer.py
@@ -246,7 +246,16 @@ class Mailer(object):
             if key in kwargs:
                 kwargs[key] = aslist(kwargs.get(key))
 
-        return cls(**kwargs)
+        username = kwargs.pop('username', None)
+        password = kwargs.pop('password', None)
+        if not (username or password):
+            # Setting both username and password to the empty string,
+            # causes repoze.sendmail.mailer.SMTPMailer to authenticate.
+            # This most likely makes no sense, so, in that case
+            # set username to None to skip authentication.
+            username = password = None
+
+        return cls(username=username, password=password, **kwargs)
 
     def send(self, message):
         """Send a message.

--- a/pyramid_mailer/tests/test_mailer.py
+++ b/pyramid_mailer/tests/test_mailer.py
@@ -247,6 +247,14 @@ class MailerTests(_Base):
         self.assertEqual(mailer.sendmail_mailer.sendmail_template,
                     ['{sendmail_app}', '--option1', '--option2', '{sender}'])
 
+    def test_from_settings_with_empty_username(self):
+        settings = {'mymail.username': '',
+                    'mymail.password': ''}
+        mailer = self._getTargetClass().from_settings(settings,
+                                                      prefix='mymail.')
+        self.assertEqual(mailer.direct_delivery.mailer.username, None)
+        self.assertEqual(mailer.direct_delivery.mailer.password, None)
+
     def test_send_immediately(self):
         import socket
         mailer = self._makeOne(host='localhost', port='28322')


### PR DESCRIPTION
This PR changes `Mailer.from_settings` to convert a blank `username` and `password` in the settings to `None`.

Setting `username` and `password` set to the empty string causes `repoze.sendmail` to authenticate to the SMTP server with an empty username and password.  This is unlikely to be useful.  Setting `username` and `password` to `None` causes `repoze.sendmail` to forego any attempt at authentication.
