### PR TITLE
Allow setting Content-Id of attachments.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 Unreleased
 ----------
 
+- Pull #71: Add a ``content_id`` argument to the ``Attachment`` constructor
+  which allows you to set the Content-ID header so you can reference it from
+  an HTML body.
+
 - TBD
 
 0.14.1 (2015-05-21)

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -132,3 +132,5 @@ Contributors
 - Nejc Zupan, 2013-11-08
 
 - Mário Idival, 2015-05-21
+
+- Ingmar Steen, 2015-08-20

--- a/pyramid_mailer/message.py
+++ b/pyramid_mailer/message.py
@@ -80,11 +80,13 @@ class Attachment(object):
         data=None,
         disposition=None,
         transfer_encoding=None,
+        content_id=None,
         ):
         self.filename = filename
         self.content_type = content_type
         self.disposition = disposition or 'attachment'
         self.transfer_encoding = transfer_encoding or 'base64'
+        self.content_id = content_id
         self._data = data
 
     @property
@@ -99,6 +101,7 @@ class Attachment(object):
         content_type = self.content_type or default_content_type
         disposition = self.disposition or 'attachment'
         transfer_encoding = self.transfer_encoding or 'base64'
+        content_id = self.content_id
 
         if not data:
             raise RuntimeError('No data provided to attachment')
@@ -137,6 +140,8 @@ class Attachment(object):
         base.set_content_type(content_type, ctparams)
         base.set_content_disposition(disposition, dparams)
         base.set_transfer_encoding(transfer_encoding)
+        if content_id:
+            base['Content-Id'] = content_id
 
         return base
 

--- a/pyramid_mailer/tests/test_message.py
+++ b/pyramid_mailer/tests/test_message.py
@@ -122,6 +122,18 @@ class TestAttachment(unittest.TestCase):
             base.get_content_disposition(),
             ('foo', {})
             )
+
+    def test_to_mailbase_content_id_set(self):
+        a = self._makeOne(
+            data='abc',
+            content_type='text/plain',
+            content_id='foo-content',
+            )
+        base = a.to_mailbase()
+        self.assertEqual(
+            base['content-id'],
+            'foo-content'
+            )
         
 class TestMessage(unittest.TestCase):
 


### PR DESCRIPTION
Closes #57.