### PR TITLE
change DebugMailer file extension from .msg to .eml

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ Unreleased
   which allows you to set the Content-ID header so you can reference it from
   an HTML body.
 
+- Pull #72: Change file extension to ``.eml`` for mails saved from
+  ``DebugMailer``. ``.eml`` is the standard file format for storing
+  plaintext MIME (rfc822) emails.
+
 0.14.1 (2015-05-21)
 -------------------
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -134,3 +134,5 @@ Contributors
 - Mário Idival, 2015-05-21
 
 - Ingmar Steen, 2015-08-20
+
+- Daniel Kraus, 2015-08-27

--- a/pyramid_mailer/mailer.py
+++ b/pyramid_mailer/mailer.py
@@ -45,7 +45,7 @@ class DebugMailer(object):
         seeds = '1234567890qwertyuiopasdfghjklzxcvbnm'
         file_part1 = datetime.now().strftime('%Y%m%d%H%M%S')
         file_part2 = ''.join(sample(seeds, 4))
-        filename = join(self.tld, '%s_%s.msg' % (file_part1, file_part2))
+        filename = join(self.tld, '%s_%s.eml' % (file_part1, file_part2))
         with open(filename, 'w') as fd:
             if not message.sender:
                 message.sender = 'nobody'

--- a/pyramid_mailer/tests/test_mailer.py
+++ b/pyramid_mailer/tests/test_mailer.py
@@ -58,6 +58,7 @@ class DebugMailerTests(_Base):
         mailer.send_sendmail(msg)
         files = self._listFiles()
         self.assertEqual(len(files), 1)
+        self.assertEqual(files[0][-4:], '.eml')
 
     def test_default_sender(self):
         mailer = self._makeOne()


### PR DESCRIPTION
I think `.eml` is the appropriate extension for saved MIME text email.
(Apple mail and thunderbird open .eml by default and after googleing around I found 
http://www.zarafa.com/wiki/index.php/Eml_vs_msg and http://stackoverflow.com/questions/16229591/difference-between-a-msg-file-and-a-eml-file )