### PR TITLE
Drop Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 sudo: false
 
 env:
-  - TOXENV=py26
   - TOXENV=py27
   - TOXENV=py32
   - TOXENV=py33

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: false
 
 env:
   - TOXENV=py27
-  - TOXENV=py32
   - TOXENV=py33
   - TOXENV=py34
   - TOXENV=pypy

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Unreleased
   ``DebugMailer``. ``.eml`` is the standard file format for storing
   plaintext MIME (rfc822) emails.
 
+- Pull #77: Drop Python 2.6 and 3.2 support.
+
 0.14.1 (2015-05-21)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,7 @@
    :alt: Documentation Status
 
 pyramid_mailer is a package for sending email from your Pyramid application.
-It is compatible with Python 2.7, 3.2, 3.3, and 3.4, as well as PyPy
-and PyPy3.
+It is compatible with Python 2.7, 3.3, and 3.4, as well as PyPy and PyPy3.
 
 This package includes:
 

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@
    :alt: Documentation Status
 
 pyramid_mailer is a package for sending email from your Pyramid application.
-It is compatible with Python 2.6. 2.7, 3.2, 3.3, and 3.4, as well as PyPy
+It is compatible with Python 2.7, 3.2, 3.3, and 3.4, as well as PyPy
 and PyPy3.
 
 This package includes:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,8 +2,8 @@ pyramid_mailer
 ==================
 
 **pyramid_mailer** is a package for the `Pyramid`_ framework to take the pain
-out of sending emails. It is compatible with Python 2.7, 3.2, 3.3, and 3.4, as
-well as PyPy and PyPy3. It has the following features:
+out of sending emails. It is compatible with Python 2.7, 3.3, and 3.4, as well
+as PyPy and PyPy3. It has the following features:
 
 1. A wrapper around the low-level email functionality of standard
    Python. This includes handling multipart emails with both text and HTML

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,8 +2,8 @@ pyramid_mailer
 ==================
 
 **pyramid_mailer** is a package for the `Pyramid`_ framework to take the pain
-out of sending emails. It is compatible with Python 2.5, 2.6, 2.7, and
-3.2. It has the following features:
+out of sending emails. It is compatible with Python 2.7, 3.2, 3.3, and 3.4, as
+well as PyPy and PyPy3. It has the following features:
 
 1. A wrapper around the low-level email functionality of standard
    Python. This includes handling multipart emails with both text and HTML

--- a/pyramid_mailer/tests/test_mailer.py
+++ b/pyramid_mailer/tests/test_mailer.py
@@ -318,7 +318,7 @@ class MailerTests(_Base):
         self.assertEqual(len(out), 1)
         first = out[0]
         self.assertEqual(first[0], 'sender@example.com')
-        self.assertEqual(first[1], set(['tester@example.com']))
+        self.assertEqual(first[1], {'tester@example.com'})
 
     def test_send_immediately_sendmail_with_exc_fail_silently(self):
         email_sender = "sender@example.com"

--- a/pyramid_mailer/tests/test_message.py
+++ b/pyramid_mailer/tests/test_message.py
@@ -618,9 +618,9 @@ class TestMessage(unittest.TestCase):
         
         self.assertEqual(
             msg.send_to,
-            set(["to@example.com",
-                 "somebodyelse@example.com",
-                 "anotherperson@example.com"])
+            {"to@example.com",
+             "somebodyelse@example.com",
+             "anotherperson@example.com"}
             )
         
     def test_is_bad_headers_if_no_bad_headers(self):

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: Implementation :: CPython",

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
         'Operating System :: OS Independent',
         "Topic :: Communications :: Email",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.2",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py26,py27,py32,py33,py34,pypy,pypy3,
+    py27,py32,py33,py34,pypy,pypy3,
     py27-pyramid{12,13,14,15},
     {py2,py3}-docs,
     {py2,py3}-cover,coverage
@@ -9,7 +9,6 @@ envlist =
 # Most of these are defaults but if you specify any you can't fall back
 # to defaults for others.
 basepython =
-    py26: python2.6
     py27: python2.7
     py32: python3.2
     py33: python3.3

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py32,py33,py34,pypy,pypy3,
+    py27,py33,py34,pypy,pypy3,
     py27-pyramid{12,13,14,15},
     {py2,py3}-docs,
     {py2,py3}-cover,coverage
@@ -10,7 +10,6 @@ envlist =
 # to defaults for others.
 basepython =
     py27: python2.7
-    py32: python3.2
     py33: python3.3
     py34: python3.4
     pypy: pypy


### PR DESCRIPTION
Yesterday marks 3 years since the last release of Python 2.6! 🎉

To celebrate, I'm attempting to drop support for it from 156 prominent Python packages (one for every week it's past end-of-life)--including this one!

I've tried my best to remove as much 2.6-specific cruft as I can, but at the very least, this PR will remove the `'Programming Language :: Python :: 2.6'` trove classifier from this projects `setup.py`.
