### PR TITLE
Fixes for #82 and #79

### DIFF
--- a/pyramid_mailer/__init__.py
+++ b/pyramid_mailer/__init__.py
@@ -20,10 +20,10 @@ def includeme(config):
     settings = config.registry.settings
     prefix = settings.get('pyramid_mailer.prefix', 'mail.')
     mailer = mailer_factory_from_settings(settings, prefix=prefix)
-    set_mailer(config, mailer)
+    _set_mailer(config, mailer)
 
 
-def set_mailer(config, mailer):
+def _set_mailer(config, mailer):
     """Set mailer in application config.
 
     Also adds a ``.mailer`` request property.

--- a/pyramid_mailer/__init__.py
+++ b/pyramid_mailer/__init__.py
@@ -20,6 +20,15 @@ def includeme(config):
     settings = config.registry.settings
     prefix = settings.get('pyramid_mailer.prefix', 'mail.')
     mailer = mailer_factory_from_settings(settings, prefix=prefix)
+    set_mailer(config, mailer)
+
+
+def set_mailer(config, mailer):
+    """Set mailer in application config.
+
+    Also adds a ``.mailer`` request property.
+
+    """
     config.registry.registerUtility(mailer, IMailer)
     if hasattr(config, 'add_request_method'):
         config.add_request_method(get_mailer, 'mailer', reify=True)

--- a/pyramid_mailer/debug.py
+++ b/pyramid_mailer/debug.py
@@ -1,9 +1,9 @@
 import os
-from pyramid_mailer.interfaces import IMailer
+from pyramid_mailer import set_mailer
 from pyramid_mailer.mailer import DebugMailer
 
 
 def includeme(config):
     path = os.path.join(os.getcwd(), 'mail')
     mailer = DebugMailer(path)
-    config.registry.registerUtility(mailer, IMailer)
+    set_mailer(config, mailer)

--- a/pyramid_mailer/debug.py
+++ b/pyramid_mailer/debug.py
@@ -1,9 +1,9 @@
 import os
-from pyramid_mailer import set_mailer
+from pyramid_mailer import _set_mailer
 from pyramid_mailer.mailer import DebugMailer
 
 
 def includeme(config):
     path = os.path.join(os.getcwd(), 'mail')
     mailer = DebugMailer(path)
-    set_mailer(config, mailer)
+    _set_mailer(config, mailer)

--- a/pyramid_mailer/mailer.py
+++ b/pyramid_mailer/mailer.py
@@ -333,13 +333,10 @@ class Mailer(object):
             sending transactional emails
 
         """
-        default_sender = kw.pop('default_sender', self.default_sender)
-        transaction_manager = kw.pop(
+        _check_bind_options(kw)
+        default_sender = kw.get('default_sender', self.default_sender)
+        transaction_manager = kw.get(
             'transaction_manager', self.transaction_manager)
-
-        if kw:
-            raise ValueError(
-                'invalid options: %s' % ', '.join(sorted(kw.keys())))
 
         return self.__class__(
             smtp_mailer=self.smtp_mailer,

--- a/pyramid_mailer/mailer.py
+++ b/pyramid_mailer/mailer.py
@@ -16,6 +16,20 @@ import transaction
 from pyramid_mailer._compat import SMTP_SSL
 
 
+def _check_bind_options(kw):
+    """Check keyword options passed to dummy mailer ``.bind`` method
+    for plausibility.
+
+    Performs the same checks that :method:`Mailer.bind` does.
+
+    """
+    valid_options = ('default_sender', 'transaction_manager')
+    invalid_options = set(kw.keys()).difference(valid_options)
+    if invalid_options:
+        raise ValueError(
+            'invalid options: %s' % ', '.join(sorted(invalid_options)))
+
+
 class DebugMailer(object):
     """ Debug mailer for testing
 
@@ -39,6 +53,21 @@ class DebugMailer(object):
             raise ValueError("DebugMailer:  must specify "
                              "'%stop_level_directory'" % prefix)
         return cls(top_level_directory)
+
+    def bind(self, **kw):
+        """Get mailer with the same server configuration but with
+        different delivery options.
+
+        This method returns ``self``, and is, essentially a no-op, but
+        is included for API compatibility with :class:`Mailer`.
+
+        :param default_sender: default "from" address
+        :param transaction_manager: a transaction manager to join with when
+            sending transactional emails
+
+        """
+        _check_bind_options(kw)
+        return self
 
     def _send(self, message, fail_silently=False):
         """Save message to a file for debugging
@@ -70,6 +99,21 @@ class DummyMailer(object):
     def __init__(self):
         self.outbox = []
         self.queue = []
+
+    def bind(self, **kw):
+        """Get mailer with the same server configuration but with
+        different delivery options.
+
+        This method returns ``self``, and is, essentially a no-op, but
+        is included for API compatibility with :class:`Mailer`.
+
+        :param default_sender: default "from" address
+        :param transaction_manager: a transaction manager to join with when
+            sending transactional emails
+
+        """
+        _check_bind_options(kw)
+        return self
 
     def send(self, message):
         """Mock sending a transactional message via SMTP.

--- a/pyramid_mailer/testing.py
+++ b/pyramid_mailer/testing.py
@@ -1,7 +1,7 @@
-from pyramid_mailer import set_mailer
+from pyramid_mailer import _set_mailer
 from pyramid_mailer.mailer import DummyMailer
 
 
 def includeme(config):
     mailer = DummyMailer()
-    set_mailer(config, mailer)
+    _set_mailer(config, mailer)

--- a/pyramid_mailer/testing.py
+++ b/pyramid_mailer/testing.py
@@ -1,6 +1,7 @@
-from pyramid_mailer.interfaces import IMailer
+from pyramid_mailer import set_mailer
 from pyramid_mailer.mailer import DummyMailer
+
 
 def includeme(config):
     mailer = DummyMailer()
-    config.registry.registerUtility(mailer, IMailer)
+    set_mailer(config, mailer)

--- a/pyramid_mailer/tests/test_debug.py
+++ b/pyramid_mailer/tests/test_debug.py
@@ -3,6 +3,7 @@ import unittest
 
 class TestIncludemeDebug(unittest.TestCase):
     def test_includeme(self):
+        from pyramid_mailer import get_mailer
         from pyramid_mailer.interfaces import IMailer
         from pyramid_mailer.mailer import DebugMailer
         from pyramid_mailer.debug import includeme
@@ -11,6 +12,10 @@ class TestIncludemeDebug(unittest.TestCase):
         config = DummyConfig(registry, {})
         includeme(config)
         self.assertEqual(registry.registered[IMailer].__class__, DebugMailer)
+        self.assertEqual(config.request_methods['mailer'], {
+            'callable': get_mailer,
+            'reify': True,
+            })
 
 
 class DummyRegistry(object):
@@ -26,5 +31,10 @@ class DummyConfig(object):
     def __init__(self, registry, settings):
         self.registry = registry
         self.registry.settings = settings
+        self.request_methods = {}
 
-
+    def add_request_method(self, callable, name, reify=False):
+        self.request_methods[name] = {
+            'callable': callable,
+            'reify': reify,
+            }

--- a/pyramid_mailer/tests/test_init.py
+++ b/pyramid_mailer/tests/test_init.py
@@ -83,6 +83,14 @@ class TestFunctional(unittest.TestCase):
         mailer = get_mailer(request)
         self.assertEqual(mailer.__class__, DummyMailer)
 
+    def test_get_mailer_dummy_with_tm(self):
+        from pyramid_mailer import get_mailer
+        from pyramid_mailer.testing import DummyMailer
+        self.config.include('pyramid_mailer.testing')
+        request = testing.DummyRequest(tm='foo')
+        mailer = get_mailer(request)
+        self.assertEqual(mailer.__class__, DummyMailer)
+
     def test_request_binding(self):
         from pyramid_mailer import get_mailer
         from pyramid_mailer.mailer import Mailer
@@ -115,5 +123,3 @@ class DummyConfig(object):
     def __init__(self, registry, settings):
         self.registry = registry
         self.registry.settings = settings
-
-

--- a/pyramid_mailer/tests/test_mailer.py
+++ b/pyramid_mailer/tests/test_mailer.py
@@ -52,6 +52,16 @@ class DebugMailerTests(_Base):
         self.assertRaises(ValueError,
                           self._getTargetClass().from_settings, None)
 
+    def test_invalid_bind_options(self):
+        mailer = self._makeOne()
+        self.assertRaises(ValueError, mailer.bind, foo='bar')
+
+    def test_bind(self):
+        mailer = self._makeOne()
+        dummy = object()
+        result = mailer.bind(transaction_manager=dummy, default_sender='foo')
+        self.assertIs(result, mailer)
+
     def test__send(self):
         mailer = self._makeOne()
         msg = _makeMessage()
@@ -78,6 +88,16 @@ class DummyMailerTests(unittest.TestCase):
 
     def _makeOne(self):
         return self._getTargetClass()()
+
+    def test_invalid_bind_options(self):
+        mailer = self._makeOne()
+        self.assertRaises(ValueError, mailer.bind, foo='bar')
+
+    def test_bind(self):
+        mailer = self._makeOne()
+        dummy = object()
+        result = mailer.bind(transaction_manager=dummy, default_sender='foo')
+        self.assertIs(result, mailer)
 
     def test_send(self):
         mailer = self._makeOne()

--- a/pyramid_mailer/tests/test_testing.py
+++ b/pyramid_mailer/tests/test_testing.py
@@ -2,6 +2,7 @@ import unittest
 
 class TestIncludemeTesting(unittest.TestCase):
     def test_includeme(self):
+        from pyramid_mailer import get_mailer
         from pyramid_mailer.interfaces import IMailer
         from pyramid_mailer.mailer import DummyMailer
         from pyramid_mailer.testing import includeme
@@ -10,6 +11,10 @@ class TestIncludemeTesting(unittest.TestCase):
         config = DummyConfig(registry, {})
         includeme(config)
         self.assertEqual(registry.registered[IMailer].__class__, DummyMailer)
+        self.assertEqual(config.request_methods['mailer'], {
+            'callable': get_mailer,
+            'reify': True,
+            })
 
 
 class DummyRegistry(object):
@@ -25,5 +30,10 @@ class DummyConfig(object):
     def __init__(self, registry, settings):
         self.registry = registry
         self.registry.settings = settings
+        self.request_methods = {}
 
-
+    def add_request_method(self, callable, name, reify=False):
+        self.request_methods[name] = {
+            'callable': callable,
+            'reify': reify,
+            }


### PR DESCRIPTION
This adds stub `DebugMailer.bind()` and `DummyMailer.bind()` methods.  (#82)
Also it fixes `pyramid_mailer.debug.includeme()`, and `pyramid_mailer.testing.includeme()` to add the `.mailer` request property. (#79)

Review welcome.