### PR TITLE
Fix internationalized messages

### DIFF
--- a/pyramid_mailer/_compat.py
+++ b/pyramid_mailer/_compat.py
@@ -20,6 +20,20 @@ except ImportError:  # pragma: no cover
 if PY2:
     # this works in Py2
     from email.encoders import _qencode
+
+    def string_to_unicode(text, encoding='utf-8'):
+        """
+        This will upgrade a Py2 `string` to a `unicode` object, preferably in `UTF-8`.
+        This is necessary for the proper escaping to happen on `Subject` and `Body`
+        """
+        if isinstance(text, bytes):
+            try:
+                # ascii in, ascii out
+                return text.decode('ascii')
+            except UnicodeDecodeError:
+                return text.decode(encoding)
+        return text
+
 else:
     # but they are broken in Py3 (_qencode was not ported properly and
     # still wants to use str instead of bytes to do space replacement)
@@ -29,3 +43,6 @@ else:
         # Must encode spaces, which quopri.encodestring() doesn't do
         return enc.replace(b' ', b'=20')
 
+    def string_to_unicode(text, encoding='utf-8'):
+        """only necessary for Py2"""
+        return text

--- a/pyramid_mailer/_compat.py
+++ b/pyramid_mailer/_compat.py
@@ -23,8 +23,8 @@ if PY2:
 
     def string_to_unicode(text, encoding='utf-8'):
         """
-        This will upgrade a Py2 `string` to a `unicode` object, preferably in `UTF-8`.
-        This is necessary for the proper escaping to happen on `Subject` and `Body`
+        This will upgrade a Py2 ``string`` to a ``unicode`` object, preferably in `UTF-8`.
+        This is necessary for the proper escaping to happen on ``Subject`` and ``Body``.
         """
         if isinstance(text, bytes):
             try:

--- a/pyramid_mailer/tests/test_message.py
+++ b/pyramid_mailer/tests/test_message.py
@@ -257,26 +257,46 @@ class TestMessage(unittest.TestCase):
 
         mailer.send(msg)
 
-    def test_body(self):
+    def test_utf8_body_subject(self):
+        """
+        This test is designed to ensure a UTF8 subject and body are encoded properly.
+
+        Two scenarios are used:
+
+            1. non-english content
+            2. emojis in content
+
+        The reason for two subtests is due to differences between PY2 and PY3
+        which make it difficult to carefully craft a single payload which
+        can satisfy both scenarios and maintain a shared set of expected test
+        results.
+        """
 
         from pyramid_mailer.message import Message
 
-        # pass 1, non-english language
-
+        # common test vars
         _ascii_content = 'testing'
+        _ascii_subject = "Subject: %s" % _ascii_content
+        _header_plain_ascii = 'Content-Type: text/plain; charset="us-ascii"'
+        _header_plain_utf8 = 'Content-Type: text/plain; charset="utf-8"'
+        _ut8_email = "Dörte@Sörensen.example.com"  # via http://kermitproject.org/utf8.html
+
+        #
+        # pass 1, non-english language
+        #
+
         _utf8_content = "Τη γλώσσα μου έδωσαν ελληνική"  # via http://kermitproject.org/utf8.html
         _utf8_content_string = _utf8_content
         _utf8_content_unicode = u"Τη γλώσσα μου έδωσαν ελληνική"  # via http://kermitproject.org/utf8.html
         if PY2:
+            # this appears to be an issue in maxchars for an email subject line differing on Python versions
+            # py2 lib/email/headers.py | MAXLINELEN = 76
             _utf8_content_encoded = '=?utf-8?b?zqTOtyDOs867z47Pg8+DzrEgzrzOv8+FIM6tzrTPic+DzrHOvSDOtc67?=\n =?utf-8?b?zrvOt869zrnOus6u?='
         else:
+            # py3 lib/email/headers.py | MAXLINELEN = 78
             _utf8_content_encoded = '=?utf-8?b?zqTOtyDOs867z47Pg8+DzrEgzrzOv8+FIM6tzrTPic+DzrHOvSDOtc67zrvOt869zrnOus6u?='
-        _ut8_email = "Dörte@Sörensen.example.com"  # via http://kermitproject.org/utf8.html
         _utf8_subject_encoded = 'Subject: %s' % _utf8_content_encoded
         _utf8_subject_string = 'Subject: %s' % _utf8_content_string  # we NEVER want to see this
-        _ascii_subject = "Subject: %s" % _ascii_content
-        _header_plain_ascii = 'Content-Type: text/plain; charset="us-ascii"'
-        _header_plain_utf8 = 'Content-Type: text/plain; charset="utf-8"'
         _utf8_content_quoted_printable = "=CE=A4=CE=B7=20=CE=B3=CE=BB=CF=8E=CF=83=CF=83=CE=B1=20=CE=BC=CE=BF=CF=85=20=\n=CE=AD=CE=B4=CF=89=CF=83=CE=B1=CE=BD=20=CE=B5=CE=BB=CE=BB=CE=B7=CE=BD=CE=B9=\n=CE=BA=CE=AE"
 
         # body: ASCII
@@ -338,22 +358,16 @@ class TestMessage(unittest.TestCase):
         self.assertIn(_ascii_subject, string2)
         self.assertIn(_utf8_content_quoted_printable, string2)
 
+        #
         # pass 2, EMOJI
+        #
 
-        _ascii_content = 'testing'
         _utf8_content = "📌 PUSHPIN!"
         _utf8_content_string = _utf8_content
         _utf8_content_unicode = u"📌 PUSHPIN!"
-        if PY2:
-            _utf8_content_encoded = '=?utf-8?b?8J+TjCBQVVNIUElOIQ==?='
-        else:
-            _utf8_content_encoded = '=?utf-8?b?8J+TjCBQVVNIUElOIQ==?='
-        _ut8_email = "Dörte@Sörensen.example.com"  # via http://kermitproject.org/utf8.html
+        _utf8_content_encoded = '=?utf-8?b?8J+TjCBQVVNIUElOIQ==?='
         _utf8_subject_encoded = 'Subject: %s' % _utf8_content_encoded
         _utf8_subject_string = 'Subject: %s' % _utf8_content_string  # we NEVER want to see this
-        _ascii_subject = "Subject: %s" % _ascii_content
-        _header_plain_ascii = 'Content-Type: text/plain; charset="us-ascii"'
-        _header_plain_utf8 = 'Content-Type: text/plain; charset="utf-8"'
         _utf8_content_quoted_printable = "F0=9F=93=8C=20PUSHPIN!"
 
 

--- a/pyramid_mailer/tests/test_message.py
+++ b/pyramid_mailer/tests/test_message.py
@@ -257,9 +257,19 @@ class TestMessage(unittest.TestCase):
 
         mailer.send(msg)
 
-    def test_utf8_body_subject(self):
+    def test_internationalized_message(self):
         """
-        This test is designed to ensure a UTF8 subject and body are encoded properly.
+        This test is designed to ensure unicode data, namely UTF-8, are encoded
+        properly in the subject and body fields, and that utf-8 email addresses
+        are not encoded for transport.
+
+        Relevant RFCs:        
+            RFC 6532 'Internationalized Email Headers'
+                https://tools.ietf.org/html/rfc6532
+            RFC 6531 'SMTP Extension for Internationalized Email'
+                https://tools.ietf.org/html/rfc6531
+           RFC 6530 'Overview and Framework for Internationalized Email'
+                https://tools.ietf.org/html/rfc6530
 
         Two scenarios are used:
 

--- a/pyramid_mailer/tests/test_message.py
+++ b/pyramid_mailer/tests/test_message.py
@@ -261,6 +261,8 @@ class TestMessage(unittest.TestCase):
 
         from pyramid_mailer.message import Message
 
+        # pass 1, non-english language
+
         _ascii_content = 'testing'
         _utf8_content = "Τη γλώσσα μου έδωσαν ελληνική"  # via http://kermitproject.org/utf8.html
         _utf8_content_string = _utf8_content
@@ -288,6 +290,85 @@ class TestMessage(unittest.TestCase):
             )
         response0 = msg0.to_message()
         string0 = response0.as_string()
+        self.assertIn(_header_plain_ascii, string0)
+        self.assertIn(_utf8_subject_encoded, string0)
+
+        # body: ASCII
+        # subject: UTF8 (py2 string)
+        msg1 = Message(
+            body=_ascii_content,
+            subject=_utf8_content,
+            sender=_ut8_email,
+            recipients=[_ut8_email],
+            cc=[_ut8_email]
+            )
+        response1 = msg1.to_message()
+        string1 = response1.as_string()
+        self.assertIn(_header_plain_ascii, string1)
+        self.assertNotIn(_utf8_subject_string, string1)
+        self.assertIn(_utf8_subject_encoded, string1)
+
+        # body: UTF8 (py2 unicode instance)
+        # subject: ASCII
+        msg2 = Message(
+            body=_utf8_content_unicode,
+            subject=_ascii_content,
+            sender=_ut8_email,
+            recipients=[_ut8_email],
+            cc=[_ut8_email]
+            )
+        response2 = msg2.to_message()
+        string2 = response2.as_string()
+        self.assertIn(_header_plain_utf8, string2)
+        self.assertIn(_ascii_subject, string2)
+        self.assertIn(_utf8_content_quoted_printable, string2)
+
+        # body: UTF8 (py2 string)
+        # subject: ASCII
+        msg3 = Message(
+            body=_utf8_content_string,
+            subject=_ascii_content,
+            sender=_ut8_email,
+            recipients=[_ut8_email],
+            cc=[_ut8_email]
+            )
+        response3 = msg3.to_message()
+        string3 = response3.as_string()
+        self.assertIn(_header_plain_utf8, string2)
+        self.assertIn(_ascii_subject, string2)
+        self.assertIn(_utf8_content_quoted_printable, string2)
+
+        # pass 2, EMOJI
+
+        _ascii_content = 'testing'
+        _utf8_content = "📌 PUSHPIN!"
+        _utf8_content_string = _utf8_content
+        _utf8_content_unicode = u"📌 PUSHPIN!"
+        if PY2:
+            _utf8_content_encoded = '=?utf-8?b?8J+TjCBQVVNIUElOIQ==?='
+        else:
+            _utf8_content_encoded = '=?utf-8?b?8J+TjCBQVVNIUElOIQ==?='
+        _ut8_email = "Dörte@Sörensen.example.com"  # via http://kermitproject.org/utf8.html
+        _utf8_subject_encoded = 'Subject: %s' % _utf8_content_encoded
+        _utf8_subject_string = 'Subject: %s' % _utf8_content_string  # we NEVER want to see this
+        _ascii_subject = "Subject: %s" % _ascii_content
+        _header_plain_ascii = 'Content-Type: text/plain; charset="us-ascii"'
+        _header_plain_utf8 = 'Content-Type: text/plain; charset="utf-8"'
+        _utf8_content_quoted_printable = "F0=9F=93=8C=20PUSHPIN!"
+
+
+        # body: ASCII
+        # subject: UTF8 (py2 unicode instance)
+        msg0 = Message(
+            body=_ascii_content,
+            subject=_utf8_content_unicode,
+            sender=_ut8_email,
+            recipients=[_ut8_email],
+            cc=[_ut8_email]
+            )
+        response0 = msg0.to_message()
+        string0 = response0.as_string()
+
         self.assertIn(_header_plain_ascii, string0)
         self.assertIn(_utf8_subject_encoded, string0)
 


### PR DESCRIPTION
This is my attempt at solving #64, which looks to be an issue in Py2 still but not Py3. 

I think the general feature was addressed in an earlier PR, but a Py2 edgecase remained.

The issue with Py2: unicode character sequences in regular strings were not encoded properly or would trigger an exception. Invoking this library with a unicode string would avoid errors and work correctly.

The Py2 fix is pretty straightforward.  A new function is defined in `_compat.py`: `string_to_unicode`. This will try decode a bytestring into a unicode object, preferring 'ascii' to a default of 'utf-8' - unicode objects pass through unchanged.  Under Py3, the function does nothing.

The function is then invoked in a few places:
*   `Attachment.to_mailbase` - only on content types that begin with 'text/'
*   `Message.to_message` - on the subject

A new test is added to ensure internationalized/emoji content works as expected in certain fields

I thought about trying to incorporate this functionality with the `best_charset` function, but I could not get it to cleanly work.