### PR TITLE
Fix the email line ending as required by RFC2822 on Python 3

### DIFF
--- a/pyramid_mailer/message.py
+++ b/pyramid_mailer/message.py
@@ -43,6 +43,11 @@ from email.mime.multipart import MIMEMultipart
 
 from email.encoders import _bencode
 
+try:
+    from email.policy import Compat32
+except ImportError:
+    Compat32 = None
+
 from .exceptions import (
     BadHeaders,
     InvalidMessage,
@@ -491,6 +496,13 @@ def to_message(base):
     for part in base.parts:
         sub = to_message(part)
         out.attach(sub)
+
+    if not PY2:
+        # the default policy on Python 3.3+ is that of Compat32, with \n
+        # line endings. This does not conform to RFC 2822 which requires
+        # that \r\n be used. The Compat32 with \r\n is the minimal change
+        # to make the bodies RFC 2822 compliant for sending.
+        out.policy = Compat32(linesep="\r\n")
 
     return out
 


### PR DESCRIPTION
Fix the email line ending as required by RFC2822 on Python 3 by using the Python 3.2 compatibility policy with custom line ending. This is indeed a bug in pyramid_mailer; the email.policy package contains different serialization formats - the one used by default uses `\n` for line endings and is thus not suitable for sending emails; for that a serializer policy that uses `\r\n` is needed.

Now one question is that if a message is queued in a file then the line endings can be changed again...
