### PR TITLE
Upgrade Python support to include 3.8 and 3.9 (Removing 2.7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ build
 docs/output
 docs/_build
 *\$py.class
+.python-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ sudo: false
 
 matrix:
   include:
-    - python: 2.7
-      env: TOXENV=py27
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5
@@ -24,10 +22,10 @@ matrix:
       env: TOXENV=py39
       dist: xenial
       sudo: true
-    - python: pypy
-      env: TOXENV=pypy
+    - python: pypy3
+      env: TOXENV=pypy3
     - python: 3.9
-      env: TOXENV=py2-cover,py3-cover,coverage
+      env: TOXENV=coverage
     - python: 3.9
       env: TOXENV=docs
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,18 +16,20 @@ matrix:
       env: TOXENV=py37
       dist: xenial
       sudo: true
-    - python: 3.8-dev
+    - python: 3.8
       env: TOXENV=py38
+      dist: xenial
+      sudo: true
+    - python: 3.9
+      env: TOXENV=py39
       dist: xenial
       sudo: true
     - python: pypy
       env: TOXENV=pypy
-    - python: 3.5
+    - python: 3.9
       env: TOXENV=py2-cover,py3-cover,coverage
-    - python: 3.5
+    - python: 3.9
       env: TOXENV=docs
-  allow_failures:
-    - env: TOXENV=py38
 
 install:
   - travis_retry pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,14 @@ matrix:
       env: TOXENV=py39
       dist: xenial
       sudo: true
+    - python: 3.9
+      env: TOXENV=py39-pyramid110
+      dist: xenial
+      sudo: true
+    - python: 3.9
+      env: TOXENV=py39-pyramid20
+      dist: xenial
+      sudo: true
     - python: pypy3
       env: TOXENV=pypy3
     - python: 3.9

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -142,3 +142,5 @@ Contributors
 - Daniel Kraus, 2015-08-27
 
 - Rami Chousein 2017-10-17
+
+- Jon Betts 2021-04-30

--- a/pyramid_mailer/_compat.py
+++ b/pyramid_mailer/_compat.py
@@ -1,8 +1,5 @@
-import sys
 import quopri
 
-
-PY2 = sys.version_info[0] < 3
 
 try:
     from smtplib import SMTP_SSL

--- a/pyramid_mailer/_compat.py
+++ b/pyramid_mailer/_compat.py
@@ -3,11 +3,6 @@ import sys
 PY2 = sys.version_info[0] < 3
 
 try:
-    text_type = unicode
-except NameError:
-    text_type = str
-
-try:
     from smtplib import SMTP_SSL
 except ImportError:  # pragma: no cover
     SMTP_SSL = None

--- a/pyramid_mailer/_compat.py
+++ b/pyramid_mailer/_compat.py
@@ -7,11 +7,6 @@ try:
 except NameError:
     text_type = str
 
-if PY2:
-    from StringIO import StringIO
-else:
-    from io import StringIO
-
 try:
     from smtplib import SMTP_SSL
 except ImportError:  # pragma: no cover

--- a/pyramid_mailer/_compat.py
+++ b/pyramid_mailer/_compat.py
@@ -1,4 +1,6 @@
 import sys
+import quopri
+
 
 PY2 = sys.version_info[0] < 3
 
@@ -7,15 +9,10 @@ try:
 except ImportError:  # pragma: no cover
     SMTP_SSL = None
 
-if PY2:
-    # this works in Py2
-    from email.encoders import _qencode
-else:
-    # but they are broken in Py3 (_qencode was not ported properly and
-    # still wants to use str instead of bytes to do space replacement)
-    import quopri
-    def _qencode(s):
-        enc = quopri.encodestring(s, quotetabs=True)
-        # Must encode spaces, which quopri.encodestring() doesn't do
-        return enc.replace(b' ', b'=20')
 
+# Patch broken _qencode in Py3 (_qencode was not ported properly and
+# still wants to use str instead of bytes to do space replacement)
+def _qencode(s):
+    enc = quopri.encodestring(s, quotetabs=True)
+    # Must encode spaces, which quopri.encodestring() doesn't do
+    return enc.replace(b' ', b'=20')

--- a/pyramid_mailer/message.py
+++ b/pyramid_mailer/message.py
@@ -48,10 +48,7 @@ from .exceptions import (
     InvalidMessage,
     )
 
-from ._compat import (
-    PY2,
-    _qencode,
-    )
+from ._compat import _qencode
 
 
 class Attachment(object):
@@ -104,7 +101,7 @@ class Attachment(object):
 
         if not data:
             raise RuntimeError('No data provided to attachment')
-        
+
         if filename and not content_type:
             content_type, _ = mimetypes.guess_type(filename)
 
@@ -119,7 +116,7 @@ class Attachment(object):
 
         if filename is None:
             filename = dparams.get('filename')
-        
+
         if filename:
             filename = os.path.split(filename)[1]
             ctparams['name'] = filename
@@ -127,9 +124,9 @@ class Attachment(object):
 
         base = MailBase()
         base.set_content_type(content_type, ctparams)
-        
+
         charset = ctparams.get('charset', None)
-        
+
         if content_type.startswith('text/'):
             if charset is None:
                 charset = best_charset(self.data)[0]
@@ -174,7 +171,7 @@ class Message(object):
         extra_headers=None,
         attachments=None
         ):
-        
+
         self.subject = subject or ''
         self.sender = sender
         self.body = body
@@ -196,7 +193,7 @@ class Message(object):
         """
 
         self.validate()
-        
+
         bodies = [(self.body, 'text/plain'), (self.html, 'text/html')]
 
         for idx, (val, content_type) in enumerate(bodies):
@@ -246,7 +243,7 @@ class Message(object):
 
         if self.cc:
             base['Cc'] = ', '.join(self.cc)
-            
+
         if self.extra_headers:
             base.update(dict(self.extra_headers))
 
@@ -256,7 +253,7 @@ class Message(object):
             base.attach_part(altpart)
         else:
             altpart = base
-            
+
         if body and html:
             altpart.set_content_type('multipart/alternative')
             altpart.set_body(None)
@@ -405,7 +402,7 @@ class MailBase(object):
     def __nonzero__(self):
         return self.body != None or len(
             self.headers) > 0 or len(self.parts) > 0
-    
+
     __bool__ = __nonzero__
 
     def keys(self):
@@ -464,15 +461,12 @@ def to_message(base):
                     charset, _ = best_charset(body)
                 else:
                     charset = 'utf-8'
-            if PY2:
-                body = body.encode(charset)
-            else:
-                body = body.encode(charset, 'surrogateescape')
+            body = body.encode(charset, 'surrogateescape')
         if body is not None:
             if ctenc:
                 body = transfer_encode(ctenc, body)
-            if not PY2:
-                body = body.decode(charset or 'ascii', 'replace')
+
+            body = body.decode(charset or 'ascii', 'replace')
         out.set_payload(body, charset)
 
     for k in base.keys(): # returned sorted

--- a/pyramid_mailer/message.py
+++ b/pyramid_mailer/message.py
@@ -49,7 +49,6 @@ from .exceptions import (
     )
 
 from ._compat import (
-    text_type,
     PY2,
     _qencode,
     )
@@ -459,7 +458,7 @@ def to_message(base):
         out = MIMENonMultipart(maintype, subtype, **ctparams)
         if ctenc:
             out['Content-Transfer-Encoding'] = ctenc
-        if isinstance(body, text_type):
+        if isinstance(body, str):
             if not charset:
                 if is_text:
                     charset, _ = best_charset(body)
@@ -506,7 +505,7 @@ def transfer_encode(encoding, payload):
         return _qencode(payload)
     elif encoding == '7bit':
         try:
-            text_type(payload, 'ascii')
+            str(payload, 'ascii')
         except UnicodeDecodeError:
             raise RuntimeError('Payload contains an octet that is not 7bit safe')
         return payload

--- a/pyramid_mailer/tests/test_message.py
+++ b/pyramid_mailer/tests/test_message.py
@@ -4,14 +4,10 @@ import unittest
 import os
 from io import StringIO
 
-from pyramid_mailer._compat import (
-    text_type,
-    _qencode,
-    )
+from pyramid_mailer._compat import _qencode
 
-from email.encoders import (
-    _bencode,
-    )
+from email.encoders import _bencode
+
 
 class TestAttachment(unittest.TestCase):
 
@@ -24,7 +20,7 @@ class TestAttachment(unittest.TestCase):
         self.assertEqual(a.data, "foo")
 
     def test_data_from_file_obj(self):
-        a = self._makeOne(data=StringIO(text_type("foo")))
+        a = self._makeOne(data=StringIO("foo"))
         self.assertEqual(a.data, "foo")
 
     def test_to_mailbase_no_data(self):
@@ -269,7 +265,7 @@ class TestMessage(unittest.TestCase):
             )
 
         response = msg.to_message()
-        self.assertTrue("Cc: tosomeoneelse@example.com" in text_type(response))
+        self.assertTrue("Cc: tosomeoneelse@example.com" in str(response))
 
     def test_cc_without_recipients(self):
 
@@ -286,7 +282,7 @@ class TestMessage(unittest.TestCase):
         msgid = mailer.send(msg)
         response = msg.to_message()
 
-        self.assertTrue("Cc: tosomeoneelse@example.com" in text_type(response))
+        self.assertTrue("Cc: tosomeoneelse@example.com" in str(response))
         self.assertTrue(msgid)
 
     def test_cc_without_recipients_2(self):
@@ -300,7 +296,7 @@ class TestMessage(unittest.TestCase):
             cc=["tosomeoneelse@example.com"]
             )
         response = msg.to_message()
-        self.assertTrue("Cc: tosomeoneelse@example.com" in text_type(response))
+        self.assertTrue("Cc: tosomeoneelse@example.com" in str(response))
 
     def test_bcc_without_recipients(self):
 
@@ -318,7 +314,7 @@ class TestMessage(unittest.TestCase):
         response = msg.to_message()
 
         self.assertFalse(
-            "Bcc: tosomeoneelse@example.com" in text_type(response))
+            "Bcc: tosomeoneelse@example.com" in str(response))
         self.assertTrue(msgid)
 
     def test_extra_headers(self):
@@ -334,7 +330,7 @@ class TestMessage(unittest.TestCase):
             )
 
         response = msg.to_message()
-        self.assertTrue("X-Foo: Joe" in text_type(response))
+        self.assertTrue("X-Foo: Joe" in str(response))
 
     def test_attach(self):
 
@@ -666,7 +662,7 @@ class TestMessage(unittest.TestCase):
             html="Html",
             )
         message = response.to_message()
-        self.assertEqual(text_type(message['To']),
+        self.assertEqual(str(message['To']),
                          'chrism@plope.com, billg@microsoft.com')
 
     def test_to_message_multipart(self):
@@ -827,7 +823,7 @@ class TestMessage(unittest.TestCase):
             )
 
         response = msg.to_message()
-        self.assertTrue("THISSHOULDBEINMESSAGEBODY" in text_type(response))
+        self.assertTrue("THISSHOULDBEINMESSAGEBODY" in str(response))
 
 class Test_normalize_header(unittest.TestCase):
     def _callFUT(self, header):

--- a/pyramid_mailer/tests/test_message.py
+++ b/pyramid_mailer/tests/test_message.py
@@ -2,10 +2,10 @@
 
 import unittest
 import os
+from io import StringIO
 
 from pyramid_mailer._compat import (
     text_type,
-    StringIO,
     _qencode,
     )
 
@@ -46,7 +46,7 @@ class TestAttachment(unittest.TestCase):
     def test_to_mailbase_content_type_cannot_be_derived_from_filename(self):
         a = self._makeOne(data='bar')
         self.assertRaises(RuntimeError, a.to_mailbase)
-        
+
     def test_to_mailbase_disposition_header_provides_filename(self):
         a = self._makeOne(
             data='bar',
@@ -134,7 +134,7 @@ class TestAttachment(unittest.TestCase):
             base['content-id'],
             'foo-content'
             )
-        
+
 class TestMessage(unittest.TestCase):
 
     def _read_filedata(self, filename, mode='r'):
@@ -144,7 +144,7 @@ class TestMessage(unittest.TestCase):
         finally:
             f.close()
         return data
-    
+
     def test_initialize(self):
 
         from pyramid_mailer.message import Message
@@ -405,7 +405,7 @@ class TestMessage(unittest.TestCase):
             )
 
         self.assertEqual(
-            html_part['Content-Type'], 
+            html_part['Content-Type'],
             'text/html; charset="iso-8859-1"'
             )
         self.assertEqual(
@@ -452,7 +452,7 @@ class TestMessage(unittest.TestCase):
             body_part['Content-Type'],
             'text/plain; charset="utf-8"'
             )
-        
+
         self.assertEqual(
             body_part['Content-Transfer-Encoding'],
             transfer_encoding
@@ -615,14 +615,14 @@ class TestMessage(unittest.TestCase):
             bcc=['anotherperson@example.com'],
             body="testing"
             )
-        
+
         self.assertEqual(
             msg.send_to,
             {"to@example.com",
              "somebodyelse@example.com",
              "anotherperson@example.com"}
             )
-        
+
     def test_is_bad_headers_if_no_bad_headers(self):
         from pyramid_mailer.message import Message
         msg = Message(
@@ -710,7 +710,7 @@ class TestMessage(unittest.TestCase):
 
     def test_to_message_multipart_with_b64encoding(self):
         from pyramid_mailer.message import Message, Attachment
-        
+
         response = Message(
             recipients=['To'],
             sender='From',
@@ -896,7 +896,7 @@ class TestMailBase(unittest.TestCase):
             base.content_encoding['Content-Transfer-Encoding'],
             'base64'
             )
-       
+
     def test_get_transfer_encoding(self):
         base = self._makeOne()
         self.assertEqual(
@@ -931,7 +931,7 @@ class TestMailBase(unittest.TestCase):
         base = self._makeOne()
         base.attach_part(1)
         self.assertEqual(base.parts, [1])
-        
+
     def test___getitem__hit(self):
         base = self._makeOne([('Content-Type', 'text/html')])
         self.assertEqual(base['content-type'], 'text/html')
@@ -1049,7 +1049,7 @@ class Test_to_message(unittest.TestCase):
         self.assertEqual(result['Content-Transfer-Encoding'], 'base64')
         payload = result.get_payload()
         self.assertEqual(payload, _bencode(b'foo').decode('ascii'))
-        
+
     def test_recursion(self):
         mail = self._makeBase()
         another = self._makeBase()
@@ -1058,7 +1058,7 @@ class Test_to_message(unittest.TestCase):
         mail.parts = [another]
         result = self._callFUT(mail)
         self.assertTrue('hello' in result.as_string())
-        
+
 class Test_transfer_encode(unittest.TestCase):
     def _callFUT(self, encoding, payload):
         from pyramid_mailer.message import transfer_encode
@@ -1089,7 +1089,7 @@ class Test_transfer_encode(unittest.TestCase):
             text_7bit
             )
         with self.assertRaises(RuntimeError):
-            self._callFUT('7bit', text_encoded) 
+            self._callFUT('7bit', text_encoded)
 
     def test_body_is_8bit(self):
         text_encoded = b'LaPe\xf1a'
@@ -1104,12 +1104,12 @@ class Test_transfer_encode(unittest.TestCase):
             RuntimeError,
             self._callFUT, 'bogus', text_encoded
             )
-        
+
 class TestFunctional(unittest.TestCase):
     def test_repoze_sendmail_send_to_queue_functional(self):
         # functest that emulates the interaction between pyramid_mailer and
         # repoze.maildir.add and queuedelivery.send.
-        
+
         import tempfile
         from email.generator import Generator
         from email.parser import Parser
@@ -1178,7 +1178,7 @@ class TestFunctional(unittest.TestCase):
                 parser = Parser()
                 reconstituted = parser.parse(foo)
                 checkit(reconstituted)
-                
+
         finally: # pragma: no cover
             try:
                 os.remove(fn)

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
         'Operating System :: OS Independent',
         "Topic :: Communications :: Email",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,8 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Framework :: Pyramid",

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,10 @@
 [tox]
 envlist =
     py34,py35,py36,py37,py38,py39,pypy3,
+    py39-pyramid{110,20}
     docs,
     coverage
+
 
 [testenv]
 # Most of these are defaults but if you specify any you can't fall back
@@ -15,7 +17,9 @@ basepython =
     py38: python3.8
     py39: python3.9
     pypy3: pypy3
-
+deps =
+    pyramid110: pyramid <= 1.10.99
+    pyramid20: pyramid <= 2.0.99
 commands =
     pip install -q pyramid_mailer[testing]
     nosetests --with-xunit --xunit-file=nosetests-{envname}.xml {posargs:}

--- a/tox.ini
+++ b/tox.ini
@@ -1,60 +1,30 @@
 [tox]
 envlist =
-    py27,py34,py35,py36,py37,py38,py39,pypy,
-    py27-pyramid{13,14,15,16,17,18,19},
+    py34,py35,py36,py37,py38,py39,pypy3,
     docs,
-    {py2,py3}-cover,coverage
+    coverage
 
 [testenv]
 # Most of these are defaults but if you specify any you can't fall back
 # to defaults for others.
 basepython =
-    py27: python2.7
     py34: python3.4
     py35: python3.5
     py36: python3.6
     py37: python3.7
     py38: python3.8
     py39: python3.9
-    pypy: pypy
     pypy3: pypy3
-    py2: python2.7
-    py3: python3.9
-
-deps =
-    pyramid13: pyramid <= 1.3.99
-    pyramid14: pyramid <= 1.4.99
-    pyramid15: pyramid <= 1.5.99
-    pyramid16: pyramid <= 1.6.99
-    pyramid17: pyramid <= 1.7.99
-    pyramid18: pyramid <= 1.8.99
-    pyramid19: pyramid <= 1.9.99
 
 commands =
     pip install -q pyramid_mailer[testing]
     nosetests --with-xunit --xunit-file=nosetests-{envname}.xml {posargs:}
 
-[testenv:py2-cover]
-commands =
-    pip install -q pyramid_mailer[testing]
-    coverage run --source=pyramid_mailer {envbindir}/nosetests
-    coverage xml -o coverage-py2.xml
-setenv =
-    COVERAGE_FILE=.coverage.py2
-
-[testenv:py3-cover]
-commands =
-    pip install -q pyramid_mailer[testing]
-    coverage run --source=pyramid_mailer {envbindir}/nosetests
-    coverage xml -o coverage-py3.xml
-setenv =
-    COVERAGE_FILE=.coverage.py3
-
 [testenv:coverage]
 basepython = python3.9
 commands =
-    coverage erase
-    coverage combine
+    pip install -q pyramid_mailer[testing]
+    coverage run --source=pyramid_mailer {envbindir}/nosetests
     coverage xml
     coverage report --show-missing --fail-under=100
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py27,py34,py35,py36,py37,pypy,
-    py27-pyramid{12,13,14,15,16,17,18,19},
+    py27,py34,py35,py36,py37,py38,py39,pypy,
+    py27-pyramid{13,14,15,16,17,18,19},
     docs,
     {py2,py3}-cover,coverage
 
@@ -15,13 +15,13 @@ basepython =
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9
     pypy: pypy
     pypy3: pypy3
     py2: python2.7
-    py3: python3.5
+    py3: python3.9
 
 deps =
-    pyramid12: pyramid <= 1.2.99
     pyramid13: pyramid <= 1.3.99
     pyramid14: pyramid <= 1.4.99
     pyramid15: pyramid <= 1.5.99
@@ -51,8 +51,8 @@ setenv =
     COVERAGE_FILE=.coverage.py3
 
 [testenv:coverage]
-basepython = python3.5
-commands = 
+basepython = python3.9
+commands =
     coverage erase
     coverage combine
     coverage xml
@@ -63,7 +63,7 @@ setenv =
     COVERAGE_FILE=.coverage
 
 [testenv:docs]
-basepython = python3.5
+basepython = python3.9
 whitelist_externals = make
 commands =
     pip install -q pyramid_mailer[docs]


### PR DESCRIPTION
This also:

 * Drops Python 2.7 support
 * Removes Python 2.7 compatibility switches
 * Combines the `coverage` steps into one
 * Updates the docs etc, to run in Python 3.9
 * No longer permits failures in Python 3.8 in Travis