### PR TITLE
remove pyramid dependency

### DIFF
--- a/pyramid_mailer/_compat.py
+++ b/pyramid_mailer/_compat.py
@@ -13,3 +13,9 @@ def _qencode(s):
     enc = quopri.encodestring(s, quotetabs=True)
     # Must encode spaces, which quopri.encodestring() doesn't do
     return enc.replace(b' ', b'=20')
+
+
+try:
+    string_types = (basestring,)
+except NameError:
+    string_types = (str,)

--- a/pyramid_mailer/mailer.py
+++ b/pyramid_mailer/mailer.py
@@ -5,15 +5,52 @@ from os.path import join
 from random import sample
 import smtplib
 
-from pyramid.settings import asbool
-from pyramid.settings import aslist
 from repoze.sendmail.mailer import SMTPMailer
 from repoze.sendmail.mailer import SendmailMailer
 from repoze.sendmail.delivery import DirectMailDelivery
 from repoze.sendmail.delivery import QueuedMailDelivery
 import transaction
 
-from pyramid_mailer._compat import SMTP_SSL
+from pyramid_mailer._compat import SMTP_SSL, string_types
+
+truthy = frozenset(('t', 'true', 'y', 'yes', 'on', '1'))
+
+
+def asbool(s):
+    """Return the boolean value ``True`` if the case-lowered value of string
+    input ``s`` is a :term:`truthy string`. If ``s`` is already one of the
+    boolean values ``True`` or ``False``, return it."""
+    if s is None:
+        return False
+    if isinstance(s, bool):
+        return s
+    s = str(s).strip()
+    return s.lower() in truthy
+
+
+def aslist_cronly(value):
+    if isinstance(value, string_types):
+        value = filter(None, [x.strip() for x in value.splitlines()])
+    return list(value)
+
+
+def aslist(value, flatten=True):
+    """Return a list, separating the input based on newlines.
+    Also if ``flatten`` is ``True`` (the default), and if the line
+    is a string, then the line will be split on spaces.
+    """
+    values = aslist_cronly(value)
+    if not flatten:
+        return values
+    result = []
+    for value in values:
+        if isinstance(value, str):
+            value = value.split()
+            result.extend(value)
+        else:
+            result.append(value)
+    return result
+
 
 
 def _check_bind_options(kw):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ docs_extras = [
     'pylons-sphinx-themes >= 1.0.10',
     ]
 
-tests_require = []
+tests_require = ['pyramid']
 
 testing_extras = tests_require + [
     'nose',
@@ -41,7 +41,6 @@ setup(
     zip_safe=False,
     platforms='any',
     install_requires=[
-        'pyramid',
         'repoze.sendmail>=4.1',
         'transaction',
     ],


### PR DESCRIPTION
Sometimes, e.g. in a containerised batch emailer, it is desirable to
use pyramid_mailer without pulling in pyramid.

The dependency exists only so that a few dozen lines of list manipulation
functions can be used.

This commit copies this code into pyramid_mailer and slightly simplifies it.