### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ It is compatible with Python 2.7, 3.4, 3.5, 3.6, and 3.7 as well as PyPy.
 This package includes:
 
 1. Wrapping the low-level Python ``email`` library with an easy-to-use
-   API, which includes attachments and mulipart content.
+   API, which includes attachments and multipart content.
 
 2. Sending emails immediately or add to a ``maildir`` queue.
 
@@ -24,7 +24,7 @@ This package includes:
 4. Features to help with unit testing.
 
 ``pyramid_mailer`` uses the ``repoze.sendmail`` library for managing email
-sending and transacton management, and borrows code (with permission) from
+sending and transaction management, and borrows code (with permission) from
 Zed Shaw's `lamson <https://github.com/zedshaw/lamson>`_  for wrapping email
 messages.  See the ``LICENSE.txt`` file for more information.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -231,7 +231,7 @@ epub_uid = 'pyramid_mailer'
 # The format is a list of tuples containing the path and title.
 # epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 # epub_post_files = []
 

--- a/pyramid_mailer/mailer.py
+++ b/pyramid_mailer/mailer.py
@@ -399,7 +399,7 @@ class Mailer(object):
     def _message_args(self, message):
 
         message.sender = message.sender or self.default_sender
-        # convert Lamson message to Python email package msessage
+        # convert Lamson message to Python email package message
         msg = message.to_message()
         return (message.sender, message.send_to, msg)
 


### PR DESCRIPTION
There are small typos in:
- README.rst
- docs/conf.py
- pyramid_mailer/mailer.py

Fixes:
- Should read `transaction` rather than `transacton`.
- Should read `that` rather than `shat`.
- Should read `multipart` rather than `mulipart`.
- Should read `message` rather than `msessage`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md